### PR TITLE
fixed 'decode is not defined' error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.11.2-stretch
 
 RUN apt-get update && \
-    curl -sL https://deb.nodesource.com/setup_11.x | bash -\
+    curl -sL https://deb.nodesource.com/setup_12.x | bash -\
     && apt-get install -y --no-install-recommends \
-    nodejs=11.2.0* \
+    nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/web-client/src/app.ts
+++ b/web-client/src/app.ts
@@ -21,6 +21,14 @@ if (!WebAssembly.instantiateStreaming) {
   };
 }
 
+function waitForDecode() {
+  if(typeof decode !== "undefined"){
+    startSession(urlData);
+  } else {
+    setTimeout(waitForDecode, 250);
+  }
+}
+
 const go = new Go();
 WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then(
   result => {
@@ -136,7 +144,7 @@ const urlData = window.location.hash.substr(1);
 console.log(urlData);
 if (urlData != "") {
   try {
-    startSession(urlData);
+    waitForDecode();
     firstInput = true;
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
Just Quick&Dirty solution for https://github.com/maxmcd/webtty/issues/5
Now I can send the connection data using # in the url