### PR TITLE
Upgrade WASM to support go 1.12+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM golang:1.11.2-stretch
+FROM golang:1.15
 
 RUN apt-get update && \
-    curl -sL https://deb.nodesource.com/setup_11.x | bash -\
+    curl -sL https://deb.nodesource.com/setup_12.x | bash -\
     && apt-get install -y --no-install-recommends \
-    nodejs=11.2.0* \
+    nodejs=12.* \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /go/src/github.com/maxmcd/webtty
-
-

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -9,8 +9,7 @@
   "main": "src/app.ts",
   "scripts": {
     "build": "npm run go-build && parcel build src/index.html --public-url .",
-    "go-build":
-      "mkdir -p ./dist/ && touch ./dist/foo && rm ./dist/* && GOOS=js GOARCH=wasm go build -o ./dist/main.wasm ./src",
+    "go-build": "mkdir -p ./dist/ && touch ./dist/foo && rm ./dist/* && GOOS=js GOARCH=wasm go build -o ./dist/main.wasm ./src",
     "serve": "parcel serve src/index.html",
     "test": "echo notests",
     "deploy": "npm run build && gh-pages -d dist"
@@ -18,11 +17,15 @@
   "author": "Max McDonnell",
   "license": "MIT",
   "dependencies": {
-    "@babel/core": "^7.1.5",
-    "@babel/runtime-corejs2": "^7.1.5",
+    "@babel/runtime-corejs2": "^7.12.5",
     "gh-pages": "^2.0.1",
     "parcel-bundler": "^1.10.3",
-    "typescript": "^3.1.6",
-    "xterm": "^3.8.0"
+    "xterm": "3.8.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.12.10",
+    "@babel/plugin-transform-runtime": "^7.12.10",
+    "cssnano": "^4.1.10",
+    "typescript": "^3.9.7"
   }
 }

--- a/web-client/src/main.go
+++ b/web-client/src/main.go
@@ -17,7 +17,7 @@ var (
 	nonce string
 )
 
-func encode(i []js.Value) {
+func encode(this js.Value, i []js.Value) interface{} {
 	encoded, err := func() (string, string) {
 		answerSd := sd.SessionDescription{
 			Sdp:   i[0].String(),
@@ -37,9 +37,10 @@ func encode(i []js.Value) {
 		return sd.Encode(answerSd), ""
 	}()
 	i[1].Invoke(encoded, err)
+	return nil
 }
 
-func decode(i []js.Value) {
+func decode(this js.Value, i []js.Value) interface{} {
 	sdp, tkbsl, err := func() (string, string, string) {
 		offer, err := sd.Decode(i[0].String())
 		if err != nil {
@@ -55,9 +56,10 @@ func decode(i []js.Value) {
 		return offer.Sdp, offer.TenKbSiteLoc, ""
 	}()
 	i[1].Invoke(sdp, tkbsl, err)
+	return nil
 }
 
 func registerCallbacks() {
-	js.Global().Set("encode", js.NewCallback(encode))
-	js.Global().Set("decode", js.NewCallback(decode))
+	js.Global().Set("encode", js.FuncOf(encode))
+	js.Global().Set("decode", js.FuncOf(decode))
 }

--- a/web-client/src/wasm_exec.js
+++ b/web-client/src/wasm_exec.js
@@ -3,444 +3,686 @@
 // license that can be found in the LICENSE file.
 
 (() => {
-	// Map web browser API and Node.js API to a single common API (preferring web standards over Node.js API).
+  // Map multiple JavaScript environments to a single common API,
+  // preferring web standards over Node.js API.
+  //
+  // Environments considered:
+  // - Browsers
+  // - Node.js
+  // - Electron
+  // - Parcel
 
-	if (typeof window !== "undefined") {
-		window.global = window;
-	} else if (typeof self !== "undefined") {
-		self.global = self;
-	} else {
-		throw new Error(
-			"cannot export Go (neither window nor self is defined)"
-		);
-	}
+  if (typeof global !== "undefined") {
+    // global already exists
+  } else if (typeof window !== "undefined") {
+    window.global = window;
+  } else if (typeof self !== "undefined") {
+    self.global = self;
+  } else {
+    throw new Error(
+      "cannot export Go (neither global, window nor self is defined)"
+    );
+  }
 
-	let outputBuf = "";
-	global.fs = {
-		constants: {
-			O_WRONLY: -1,
-			O_RDWR: -1,
-			O_CREAT: -1,
-			O_TRUNC: -1,
-			O_APPEND: -1,
-			O_EXCL: -1
-		}, // unused
-		writeSync(fd, buf) {
-			outputBuf += decoder.decode(buf);
-			const nl = outputBuf.lastIndexOf("\n");
-			if (nl != -1) {
-				console.log(outputBuf.substr(0, nl));
-				outputBuf = outputBuf.substr(nl + 1);
-			}
-			return buf.length;
-		},
-		openSync(path, flags, mode) {
-			const err = new Error("not implemented");
-			err.code = "ENOSYS";
-			throw err;
-		}
-	};
+  if (!global.require && typeof require !== "undefined") {
+    global.require = require;
+  }
 
-	const encoder = new TextEncoder("utf-8");
-	const decoder = new TextDecoder("utf-8");
+  if (!global.fs && global.require) {
+    const fs = require("fs");
+    if (Object.keys(fs) !== 0) {
+      global.fs = fs;
+    }
+  }
 
-	global.Go = class {
-		constructor() {
-			this.argv = ["js"];
-			this.env = {};
-			this.exit = code => {
-				if (code !== 0) {
-					console.warn("exit code:", code);
-				}
-			};
-			this._callbackTimeouts = new Map();
-			this._nextCallbackTimeoutID = 1;
+  const enosys = () => {
+    const err = new Error("not implemented");
+    err.code = "ENOSYS";
+    return err;
+  };
 
-			const mem = () => {
-				// The buffer may change when requesting more memory.
-				return new DataView(this._inst.exports.mem.buffer);
-			};
+  let outputBuf = "";
+  global.fs = {
+    constants: {
+      O_WRONLY: -1,
+      O_RDWR: -1,
+      O_CREAT: -1,
+      O_TRUNC: -1,
+      O_APPEND: -1,
+      O_EXCL: -1,
+    }, // unused
+    writeSync(fd, buf) {
+      outputBuf += decoder.decode(buf);
+      const nl = outputBuf.lastIndexOf("\n");
+      if (nl != -1) {
+        console.log(outputBuf.substr(0, nl));
+        outputBuf = outputBuf.substr(nl + 1);
+      }
+      return buf.length;
+    },
+    write(fd, buf, offset, length, position, callback) {
+      if (offset !== 0 || length !== buf.length || position !== null) {
+        callback(enosys());
+        return;
+      }
+      const n = this.writeSync(fd, buf);
+      callback(null, n);
+    },
+    chmod(path, mode, callback) {
+      callback(enosys());
+    },
+    chown(path, uid, gid, callback) {
+      callback(enosys());
+    },
+    close(fd, callback) {
+      callback(enosys());
+    },
+    fchmod(fd, mode, callback) {
+      callback(enosys());
+    },
+    fchown(fd, uid, gid, callback) {
+      callback(enosys());
+    },
+    fstat(fd, callback) {
+      callback(enosys());
+    },
+    fsync(fd, callback) {
+      callback(null);
+    },
+    ftruncate(fd, length, callback) {
+      callback(enosys());
+    },
+    lchown(path, uid, gid, callback) {
+      callback(enosys());
+    },
+    link(path, link, callback) {
+      callback(enosys());
+    },
+    lstat(path, callback) {
+      callback(enosys());
+    },
+    mkdir(path, perm, callback) {
+      callback(enosys());
+    },
+    open(path, flags, mode, callback) {
+      callback(enosys());
+    },
+    read(fd, buffer, offset, length, position, callback) {
+      callback(enosys());
+    },
+    readdir(path, callback) {
+      callback(enosys());
+    },
+    readlink(path, callback) {
+      callback(enosys());
+    },
+    rename(from, to, callback) {
+      callback(enosys());
+    },
+    rmdir(path, callback) {
+      callback(enosys());
+    },
+    stat(path, callback) {
+      callback(enosys());
+    },
+    symlink(path, link, callback) {
+      callback(enosys());
+    },
+    truncate(path, length, callback) {
+      callback(enosys());
+    },
+    unlink(path, callback) {
+      callback(enosys());
+    },
+    utimes(path, atime, mtime, callback) {
+      callback(enosys());
+    },
+  };
 
-			const setInt64 = (addr, v) => {
-				mem().setUint32(addr + 0, v, true);
-				mem().setUint32(addr + 4, Math.floor(v / 4294967296), true);
-			};
+  if (!global.process) {
+    global.process = {
+      getuid() {
+        return -1;
+      },
+      getgid() {
+        return -1;
+      },
+      geteuid() {
+        return -1;
+      },
+      getegid() {
+        return -1;
+      },
+      getgroups() {
+        throw enosys();
+      },
+      pid: -1,
+      ppid: -1,
+      umask() {
+        throw enosys();
+      },
+      cwd() {
+        throw enosys();
+      },
+      chdir() {
+        throw enosys();
+      },
+    };
+  }
 
-			const getInt64 = addr => {
-				const low = mem().getUint32(addr + 0, true);
-				const high = mem().getInt32(addr + 4, true);
-				return low + high * 4294967296;
-			};
+  if (!global.crypto) {
+    const nodeCrypto = require("crypto");
+    global.crypto = {
+      getRandomValues(b) {
+        nodeCrypto.randomFillSync(b);
+      },
+    };
+  }
 
-			const loadValue = addr => {
-				const f = mem().getFloat64(addr, true);
-				if (!isNaN(f)) {
-					return f;
-				}
+  if (!global.performance) {
+    global.performance = {
+      now() {
+        const [sec, nsec] = process.hrtime();
+        return sec * 1000 + nsec / 1000000;
+      },
+    };
+  }
 
-				const id = mem().getUint32(addr, true);
-				return this._values[id];
-			};
+  if (!global.TextEncoder) {
+    global.TextEncoder = require("util").TextEncoder;
+  }
 
-			const storeValue = (addr, v) => {
-				const nanHead = 0x7ff80000;
+  if (!global.TextDecoder) {
+    global.TextDecoder = require("util").TextDecoder;
+  }
 
-				if (typeof v === "number") {
-					if (isNaN(v)) {
-						mem().setUint32(addr + 4, nanHead, true);
-						mem().setUint32(addr, 0, true);
-						return;
-					}
-					mem().setFloat64(addr, v, true);
-					return;
-				}
+  // End of polyfills for common API.
 
-				switch (v) {
-					case undefined:
-						mem().setUint32(addr + 4, nanHead, true);
-						mem().setUint32(addr, 1, true);
-						return;
-					case null:
-						mem().setUint32(addr + 4, nanHead, true);
-						mem().setUint32(addr, 2, true);
-						return;
-					case true:
-						mem().setUint32(addr + 4, nanHead, true);
-						mem().setUint32(addr, 3, true);
-						return;
-					case false:
-						mem().setUint32(addr + 4, nanHead, true);
-						mem().setUint32(addr, 4, true);
-						return;
-				}
+  const encoder = new TextEncoder("utf-8");
+  const decoder = new TextDecoder("utf-8");
 
-				let ref = this._refs.get(v);
-				if (ref === undefined) {
-					ref = this._values.length;
-					this._values.push(v);
-					this._refs.set(v, ref);
-				}
-				let typeFlag = 0;
-				switch (typeof v) {
-					case "string":
-						typeFlag = 1;
-						break;
-					case "symbol":
-						typeFlag = 2;
-						break;
-					case "function":
-						typeFlag = 3;
-						break;
-				}
-				mem().setUint32(addr + 4, nanHead | typeFlag, true);
-				mem().setUint32(addr, ref, true);
-			};
+  global.Go = class {
+    constructor() {
+      this.argv = ["js"];
+      this.env = {};
+      this.exit = (code) => {
+        if (code !== 0) {
+          console.warn("exit code:", code);
+        }
+      };
+      this._exitPromise = new Promise((resolve) => {
+        this._resolveExitPromise = resolve;
+      });
+      this._pendingEvent = null;
+      this._scheduledTimeouts = new Map();
+      this._nextCallbackTimeoutID = 1;
 
-			const loadSlice = addr => {
-				const array = getInt64(addr + 0);
-				const len = getInt64(addr + 8);
-				return new Uint8Array(
-					this._inst.exports.mem.buffer,
-					array,
-					len
-				);
-			};
+      const setInt64 = (addr, v) => {
+        this.mem.setUint32(addr + 0, v, true);
+        this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
+      };
 
-			const loadSliceOfValues = addr => {
-				const array = getInt64(addr + 0);
-				const len = getInt64(addr + 8);
-				const a = new Array(len);
-				for (let i = 0; i < len; i++) {
-					a[i] = loadValue(array + i * 8);
-				}
-				return a;
-			};
+      const getInt64 = (addr) => {
+        const low = this.mem.getUint32(addr + 0, true);
+        const high = this.mem.getInt32(addr + 4, true);
+        return low + high * 4294967296;
+      };
 
-			const loadString = addr => {
-				const saddr = getInt64(addr + 0);
-				const len = getInt64(addr + 8);
-				return decoder.decode(
-					new DataView(this._inst.exports.mem.buffer, saddr, len)
-				);
-			};
+      const loadValue = (addr) => {
+        const f = this.mem.getFloat64(addr, true);
+        if (f === 0) {
+          return undefined;
+        }
+        if (!isNaN(f)) {
+          return f;
+        }
 
-			const timeOrigin = Date.now() - performance.now();
-			this.importObject = {
-				go: {
-					// func wasmExit(code int32)
-					"runtime.wasmExit": sp => {
-						const code = mem().getInt32(sp + 8, true);
-						this.exited = true;
-						delete this._inst;
-						delete this._values;
-						delete this._refs;
-						this.exit(code);
-					},
+        const id = this.mem.getUint32(addr, true);
+        return this._values[id];
+      };
 
-					// func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
-					"runtime.wasmWrite": sp => {
-						const fd = getInt64(sp + 8);
-						const p = getInt64(sp + 16);
-						const n = mem().getInt32(sp + 24, true);
-						fs.writeSync(
-							fd,
-							new Uint8Array(this._inst.exports.mem.buffer, p, n)
-						);
-					},
+      const storeValue = (addr, v) => {
+        const nanHead = 0x7ff80000;
 
-					// func nanotime() int64
-					"runtime.nanotime": sp => {
-						setInt64(
-							sp + 8,
-							(timeOrigin + performance.now()) * 1000000
-						);
-					},
+        if (typeof v === "number" && v !== 0) {
+          if (isNaN(v)) {
+            this.mem.setUint32(addr + 4, nanHead, true);
+            this.mem.setUint32(addr, 0, true);
+            return;
+          }
+          this.mem.setFloat64(addr, v, true);
+          return;
+        }
 
-					// func walltime() (sec int64, nsec int32)
-					"runtime.walltime": sp => {
-						const msec = new Date().getTime();
-						setInt64(sp + 8, msec / 1000);
-						mem().setInt32(sp + 16, (msec % 1000) * 1000000, true);
-					},
+        if (v === undefined) {
+          this.mem.setFloat64(addr, 0, true);
+          return;
+        }
 
-					// func scheduleCallback(delay int64) int32
-					"runtime.scheduleCallback": sp => {
-						const id = this._nextCallbackTimeoutID;
-						this._nextCallbackTimeoutID++;
-						this._callbackTimeouts.set(
-							id,
-							setTimeout(
-								() => {
-									this._resolveCallbackPromise();
-								},
-								getInt64(sp + 8) + 1 // setTimeout has been seen to fire up to 1 millisecond early
-							)
-						);
-						mem().setInt32(sp + 16, id, true);
-					},
+        let id = this._ids.get(v);
+        if (id === undefined) {
+          id = this._idPool.pop();
+          if (id === undefined) {
+            id = this._values.length;
+          }
+          this._values[id] = v;
+          this._goRefCounts[id] = 0;
+          this._ids.set(v, id);
+        }
+        this._goRefCounts[id]++;
+        let typeFlag = 0;
+        switch (typeof v) {
+          case "object":
+            if (v !== null) {
+              typeFlag = 1;
+            }
+            break;
+          case "string":
+            typeFlag = 2;
+            break;
+          case "symbol":
+            typeFlag = 3;
+            break;
+          case "function":
+            typeFlag = 4;
+            break;
+        }
+        this.mem.setUint32(addr + 4, nanHead | typeFlag, true);
+        this.mem.setUint32(addr, id, true);
+      };
 
-					// func clearScheduledCallback(id int32)
-					"runtime.clearScheduledCallback": sp => {
-						const id = mem().getInt32(sp + 8, true);
-						clearTimeout(this._callbackTimeouts.get(id));
-						this._callbackTimeouts.delete(id);
-					},
+      const loadSlice = (addr) => {
+        const array = getInt64(addr + 0);
+        const len = getInt64(addr + 8);
+        return new Uint8Array(this._inst.exports.mem.buffer, array, len);
+      };
 
-					// func getRandomData(r []byte)
-					"runtime.getRandomData": sp => {
-						crypto.getRandomValues(loadSlice(sp + 8));
-					},
+      const loadSliceOfValues = (addr) => {
+        const array = getInt64(addr + 0);
+        const len = getInt64(addr + 8);
+        const a = new Array(len);
+        for (let i = 0; i < len; i++) {
+          a[i] = loadValue(array + i * 8);
+        }
+        return a;
+      };
 
-					// func stringVal(value string) ref
-					"syscall/js.stringVal": sp => {
-						storeValue(sp + 24, loadString(sp + 8));
-					},
+      const loadString = (addr) => {
+        const saddr = getInt64(addr + 0);
+        const len = getInt64(addr + 8);
+        return decoder.decode(
+          new DataView(this._inst.exports.mem.buffer, saddr, len)
+        );
+      };
 
-					// func valueGet(v ref, p string) ref
-					"syscall/js.valueGet": sp => {
-						storeValue(
-							sp + 32,
-							Reflect.get(loadValue(sp + 8), loadString(sp + 16))
-						);
-					},
+      const timeOrigin = Date.now() - performance.now();
+      this.importObject = {
+        go: {
+          // Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
+          // may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
+          // function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
+          // This changes the SP, thus we have to update the SP used by the imported function.
 
-					// func valueSet(v ref, p string, x ref)
-					"syscall/js.valueSet": sp => {
-						Reflect.set(
-							loadValue(sp + 8),
-							loadString(sp + 16),
-							loadValue(sp + 32)
-						);
-					},
+          // func wasmExit(code int32)
+          "runtime.wasmExit": (sp) => {
+            const code = this.mem.getInt32(sp + 8, true);
+            this.exited = true;
+            delete this._inst;
+            delete this._values;
+            delete this._goRefCounts;
+            delete this._ids;
+            delete this._idPool;
+            this.exit(code);
+          },
 
-					// func valueIndex(v ref, i int) ref
-					"syscall/js.valueIndex": sp => {
-						storeValue(
-							sp + 24,
-							Reflect.get(loadValue(sp + 8), getInt64(sp + 16))
-						);
-					},
+          // func wasmWrite(fd uintptr, p unsafe.Pointer, n int32)
+          "runtime.wasmWrite": (sp) => {
+            const fd = getInt64(sp + 8);
+            const p = getInt64(sp + 16);
+            const n = this.mem.getInt32(sp + 24, true);
+            fs.writeSync(
+              fd,
+              new Uint8Array(this._inst.exports.mem.buffer, p, n)
+            );
+          },
 
-					// valueSetIndex(v ref, i int, x ref)
-					"syscall/js.valueSetIndex": sp => {
-						Reflect.set(
-							loadValue(sp + 8),
-							getInt64(sp + 16),
-							loadValue(sp + 24)
-						);
-					},
+          // func resetMemoryDataView()
+          "runtime.resetMemoryDataView": (sp) => {
+            this.mem = new DataView(this._inst.exports.mem.buffer);
+          },
 
-					// func valueCall(v ref, m string, args []ref) (ref, bool)
-					"syscall/js.valueCall": sp => {
-						try {
-							const v = loadValue(sp + 8);
-							const m = Reflect.get(v, loadString(sp + 16));
-							const args = loadSliceOfValues(sp + 32);
-							storeValue(sp + 56, Reflect.apply(m, v, args));
-							mem().setUint8(sp + 64, 1);
-						} catch (err) {
-							storeValue(sp + 56, err);
-							mem().setUint8(sp + 64, 0);
-						}
-					},
+          // func nanotime1() int64
+          "runtime.nanotime1": (sp) => {
+            setInt64(sp + 8, (timeOrigin + performance.now()) * 1000000);
+          },
 
-					// func valueInvoke(v ref, args []ref) (ref, bool)
-					"syscall/js.valueInvoke": sp => {
-						try {
-							const v = loadValue(sp + 8);
-							const args = loadSliceOfValues(sp + 16);
-							storeValue(
-								sp + 40,
-								Reflect.apply(v, undefined, args)
-							);
-							mem().setUint8(sp + 48, 1);
-						} catch (err) {
-							storeValue(sp + 40, err);
-							mem().setUint8(sp + 48, 0);
-						}
-					},
+          // func walltime1() (sec int64, nsec int32)
+          "runtime.walltime1": (sp) => {
+            const msec = new Date().getTime();
+            setInt64(sp + 8, msec / 1000);
+            this.mem.setInt32(sp + 16, (msec % 1000) * 1000000, true);
+          },
 
-					// func valueNew(v ref, args []ref) (ref, bool)
-					"syscall/js.valueNew": sp => {
-						try {
-							const v = loadValue(sp + 8);
-							const args = loadSliceOfValues(sp + 16);
-							storeValue(sp + 40, Reflect.construct(v, args));
-							mem().setUint8(sp + 48, 1);
-						} catch (err) {
-							storeValue(sp + 40, err);
-							mem().setUint8(sp + 48, 0);
-						}
-					},
+          // func scheduleTimeoutEvent(delay int64) int32
+          "runtime.scheduleTimeoutEvent": (sp) => {
+            const id = this._nextCallbackTimeoutID;
+            this._nextCallbackTimeoutID++;
+            this._scheduledTimeouts.set(
+              id,
+              setTimeout(
+                () => {
+                  this._resume();
+                  while (this._scheduledTimeouts.has(id)) {
+                    // for some reason Go failed to register the timeout event, log and try again
+                    // (temporary workaround for https://github.com/golang/go/issues/28975)
+                    console.warn("scheduleTimeoutEvent: missed timeout event");
+                    this._resume();
+                  }
+                },
+                getInt64(sp + 8) + 1 // setTimeout has been seen to fire up to 1 millisecond early
+              )
+            );
+            this.mem.setInt32(sp + 16, id, true);
+          },
 
-					// func valueLength(v ref) int
-					"syscall/js.valueLength": sp => {
-						setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
-					},
+          // func clearTimeoutEvent(id int32)
+          "runtime.clearTimeoutEvent": (sp) => {
+            const id = this.mem.getInt32(sp + 8, true);
+            clearTimeout(this._scheduledTimeouts.get(id));
+            this._scheduledTimeouts.delete(id);
+          },
 
-					// valuePrepareString(v ref) (ref, int)
-					"syscall/js.valuePrepareString": sp => {
-						const str = encoder.encode(String(loadValue(sp + 8)));
-						storeValue(sp + 16, str);
-						setInt64(sp + 24, str.length);
-					},
+          // func getRandomData(r []byte)
+          "runtime.getRandomData": (sp) => {
+            crypto.getRandomValues(loadSlice(sp + 8));
+          },
 
-					// valueLoadString(v ref, b []byte)
-					"syscall/js.valueLoadString": sp => {
-						const str = loadValue(sp + 8);
-						loadSlice(sp + 16).set(str);
-					},
+          // func finalizeRef(v ref)
+          "syscall/js.finalizeRef": (sp) => {
+            const id = this.mem.getUint32(sp + 8, true);
+            this._goRefCounts[id]--;
+            if (this._goRefCounts[id] === 0) {
+              const v = this._values[id];
+              this._values[id] = null;
+              this._ids.delete(v);
+              this._idPool.push(id);
+            }
+          },
 
-					// func valueInstanceOf(v ref, t ref) bool
-					"syscall/js.valueInstanceOf": sp => {
-						mem().setUint8(
-							sp + 24,
-							loadValue(sp + 8) instanceof loadValue(sp + 16)
-						);
-					},
+          // func stringVal(value string) ref
+          "syscall/js.stringVal": (sp) => {
+            storeValue(sp + 24, loadString(sp + 8));
+          },
 
-					debug: value => {
-						console.log(value);
-					}
-				}
-			};
-		}
+          // func valueGet(v ref, p string) ref
+          "syscall/js.valueGet": (sp) => {
+            const result = Reflect.get(loadValue(sp + 8), loadString(sp + 16));
+            sp = this._inst.exports.getsp(); // see comment above
+            storeValue(sp + 32, result);
+          },
 
-		async run(instance) {
-			this._inst = instance;
-			this._values = [
-				// TODO: garbage collection
-				NaN,
-				undefined,
-				null,
-				true,
-				false,
-				global,
-				this._inst.exports.mem,
-				this
-			];
-			this._refs = new Map();
-			this._callbackShutdown = false;
-			this.exited = false;
+          // func valueSet(v ref, p string, x ref)
+          "syscall/js.valueSet": (sp) => {
+            Reflect.set(
+              loadValue(sp + 8),
+              loadString(sp + 16),
+              loadValue(sp + 32)
+            );
+          },
 
-			const mem = new DataView(this._inst.exports.mem.buffer);
+          // func valueDelete(v ref, p string)
+          "syscall/js.valueDelete": (sp) => {
+            Reflect.deleteProperty(loadValue(sp + 8), loadString(sp + 16));
+          },
 
-			// Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
-			let offset = 4096;
+          // func valueIndex(v ref, i int) ref
+          "syscall/js.valueIndex": (sp) => {
+            storeValue(
+              sp + 24,
+              Reflect.get(loadValue(sp + 8), getInt64(sp + 16))
+            );
+          },
 
-			const strPtr = str => {
-				let ptr = offset;
-				new Uint8Array(mem.buffer, offset, str.length + 1).set(
-					encoder.encode(str + "\0")
-				);
-				offset += str.length + (8 - str.length % 8);
-				return ptr;
-			};
+          // valueSetIndex(v ref, i int, x ref)
+          "syscall/js.valueSetIndex": (sp) => {
+            Reflect.set(
+              loadValue(sp + 8),
+              getInt64(sp + 16),
+              loadValue(sp + 24)
+            );
+          },
 
-			const argc = this.argv.length;
+          // func valueCall(v ref, m string, args []ref) (ref, bool)
+          "syscall/js.valueCall": (sp) => {
+            try {
+              const v = loadValue(sp + 8);
+              const m = Reflect.get(v, loadString(sp + 16));
+              const args = loadSliceOfValues(sp + 32);
+              const result = Reflect.apply(m, v, args);
+              sp = this._inst.exports.getsp(); // see comment above
+              storeValue(sp + 56, result);
+              this.mem.setUint8(sp + 64, 1);
+            } catch (err) {
+              storeValue(sp + 56, err);
+              this.mem.setUint8(sp + 64, 0);
+            }
+          },
 
-			const argvPtrs = [];
-			this.argv.forEach(arg => {
-				argvPtrs.push(strPtr(arg));
-			});
+          // func valueInvoke(v ref, args []ref) (ref, bool)
+          "syscall/js.valueInvoke": (sp) => {
+            try {
+              const v = loadValue(sp + 8);
+              const args = loadSliceOfValues(sp + 16);
+              const result = Reflect.apply(v, undefined, args);
+              sp = this._inst.exports.getsp(); // see comment above
+              storeValue(sp + 40, result);
+              this.mem.setUint8(sp + 48, 1);
+            } catch (err) {
+              storeValue(sp + 40, err);
+              this.mem.setUint8(sp + 48, 0);
+            }
+          },
 
-			const keys = Object.keys(this.env).sort();
-			argvPtrs.push(keys.length);
-			keys.forEach(key => {
-				argvPtrs.push(strPtr(`${key}=${this.env[key]}`));
-			});
+          // func valueNew(v ref, args []ref) (ref, bool)
+          "syscall/js.valueNew": (sp) => {
+            try {
+              const v = loadValue(sp + 8);
+              const args = loadSliceOfValues(sp + 16);
+              const result = Reflect.construct(v, args);
+              sp = this._inst.exports.getsp(); // see comment above
+              storeValue(sp + 40, result);
+              this.mem.setUint8(sp + 48, 1);
+            } catch (err) {
+              storeValue(sp + 40, err);
+              this.mem.setUint8(sp + 48, 0);
+            }
+          },
 
-			const argv = offset;
-			argvPtrs.forEach(ptr => {
-				mem.setUint32(offset, ptr, true);
-				mem.setUint32(offset + 4, 0, true);
-				offset += 8;
-			});
+          // func valueLength(v ref) int
+          "syscall/js.valueLength": (sp) => {
+            setInt64(sp + 16, parseInt(loadValue(sp + 8).length));
+          },
 
-			while (true) {
-				const callbackPromise = new Promise(resolve => {
-					this._resolveCallbackPromise = () => {
-						if (this.exited) {
-							throw new Error(
-								"bad callback: Go program has already exited"
-							);
-						}
-						setTimeout(resolve, 0); // make sure it is asynchronous
-					};
-				});
-				this._inst.exports.run(argc, argv);
-				if (this.exited) {
-					break;
-				}
-				await callbackPromise;
-			}
-		}
+          // valuePrepareString(v ref) (ref, int)
+          "syscall/js.valuePrepareString": (sp) => {
+            const str = encoder.encode(String(loadValue(sp + 8)));
+            storeValue(sp + 16, str);
+            setInt64(sp + 24, str.length);
+          },
 
-		static _makeCallbackHelper(id, pendingCallbacks, go) {
-			return function() {
-				pendingCallbacks.push({ id: id, args: arguments });
-				go._resolveCallbackPromise();
-			};
-		}
+          // valueLoadString(v ref, b []byte)
+          "syscall/js.valueLoadString": (sp) => {
+            const str = loadValue(sp + 8);
+            loadSlice(sp + 16).set(str);
+          },
 
-		static _makeEventCallbackHelper(
-			preventDefault,
-			stopPropagation,
-			stopImmediatePropagation,
-			fn
-		) {
-			return function(event) {
-				if (preventDefault) {
-					event.preventDefault();
-				}
-				if (stopPropagation) {
-					event.stopPropagation();
-				}
-				if (stopImmediatePropagation) {
-					event.stopImmediatePropagation();
-				}
-				fn(event);
-			};
-		}
-	};
+          // func valueInstanceOf(v ref, t ref) bool
+          "syscall/js.valueInstanceOf": (sp) => {
+            this.mem.setUint8(
+              sp + 24,
+              loadValue(sp + 8) instanceof loadValue(sp + 16) ? 1 : 0
+            );
+          },
+
+          // func copyBytesToGo(dst []byte, src ref) (int, bool)
+          "syscall/js.copyBytesToGo": (sp) => {
+            const dst = loadSlice(sp + 8);
+            const src = loadValue(sp + 32);
+            if (
+              !(src instanceof Uint8Array || src instanceof Uint8ClampedArray)
+            ) {
+              this.mem.setUint8(sp + 48, 0);
+              return;
+            }
+            const toCopy = src.subarray(0, dst.length);
+            dst.set(toCopy);
+            setInt64(sp + 40, toCopy.length);
+            this.mem.setUint8(sp + 48, 1);
+          },
+
+          // func copyBytesToJS(dst ref, src []byte) (int, bool)
+          "syscall/js.copyBytesToJS": (sp) => {
+            const dst = loadValue(sp + 8);
+            const src = loadSlice(sp + 16);
+            if (
+              !(dst instanceof Uint8Array || dst instanceof Uint8ClampedArray)
+            ) {
+              this.mem.setUint8(sp + 48, 0);
+              return;
+            }
+            const toCopy = src.subarray(0, dst.length);
+            dst.set(toCopy);
+            setInt64(sp + 40, toCopy.length);
+            this.mem.setUint8(sp + 48, 1);
+          },
+
+          debug: (value) => {
+            console.log(value);
+          },
+        },
+      };
+    }
+
+    async run(instance) {
+      this._inst = instance;
+      this.mem = new DataView(this._inst.exports.mem.buffer);
+      this._values = [
+        // JS values that Go currently has references to, indexed by reference id
+        NaN,
+        0,
+        null,
+        true,
+        false,
+        global,
+        this,
+      ];
+      this._goRefCounts = new Array(this._values.length).fill(Infinity); // number of references that Go has to a JS value, indexed by reference id
+      this._ids = new Map([
+        // mapping from JS values to reference ids
+        [0, 1],
+        [null, 2],
+        [true, 3],
+        [false, 4],
+        [global, 5],
+        [this, 6],
+      ]);
+      this._idPool = []; // unused ids that have been garbage collected
+      this.exited = false; // whether the Go program has exited
+
+      // Pass command line arguments and environment variables to WebAssembly by writing them to the linear memory.
+      let offset = 4096;
+
+      const strPtr = (str) => {
+        const ptr = offset;
+        const bytes = encoder.encode(str + "\0");
+        new Uint8Array(this.mem.buffer, offset, bytes.length).set(bytes);
+        offset += bytes.length;
+        if (offset % 8 !== 0) {
+          offset += 8 - (offset % 8);
+        }
+        return ptr;
+      };
+
+      const argc = this.argv.length;
+
+      const argvPtrs = [];
+      this.argv.forEach((arg) => {
+        argvPtrs.push(strPtr(arg));
+      });
+      argvPtrs.push(0);
+
+      const keys = Object.keys(this.env).sort();
+      keys.forEach((key) => {
+        argvPtrs.push(strPtr(`${key}=${this.env[key]}`));
+      });
+      argvPtrs.push(0);
+
+      const argv = offset;
+      argvPtrs.forEach((ptr) => {
+        this.mem.setUint32(offset, ptr, true);
+        this.mem.setUint32(offset + 4, 0, true);
+        offset += 8;
+      });
+
+      this._inst.exports.run(argc, argv);
+      if (this.exited) {
+        this._resolveExitPromise();
+      }
+      await this._exitPromise;
+    }
+
+    _resume() {
+      if (this.exited) {
+        throw new Error("Go program has already exited");
+      }
+      this._inst.exports.resume();
+      if (this.exited) {
+        this._resolveExitPromise();
+      }
+    }
+
+    _makeFuncWrapper(id) {
+      const go = this;
+      return function () {
+        const event = { id: id, this: this, args: arguments };
+        go._pendingEvent = event;
+        go._resume();
+        return event.result;
+      };
+    }
+  };
+
+  if (
+    global.require &&
+    global.require.main === module &&
+    global.process &&
+    global.process.versions &&
+    !global.process.versions.electron
+  ) {
+    if (process.argv.length < 3) {
+      console.error("usage: go_js_wasm_exec [wasm binary] [arguments]");
+      process.exit(1);
+    }
+
+    const go = new Go();
+    go.argv = process.argv.slice(2);
+    go.env = Object.assign({ TMPDIR: require("os").tmpdir() }, process.env);
+    go.exit = process.exit;
+    WebAssembly.instantiate(fs.readFileSync(process.argv[2]), go.importObject)
+      .then((result) => {
+        process.on("exit", (code) => {
+          // Node.js exits if no event handler is pending
+          if (code === 0 && !go.exited) {
+            // deadlock, make Go print error and stack traces
+            go._pendingEvent = { id: 0 };
+            go._resume();
+          }
+        });
+        return go.run(result.instance);
+      })
+      .catch((err) => {
+        console.error(err);
+        process.exit(1);
+      });
+  }
 })();


### PR DESCRIPTION
related to #29 

@Sean-Der we might want to dockerize the the build process, or somehow enforce building with go 1.15, since wasm_exec.js is a moving target. Thoughts?

Additionally I could add to your github actions tests to test this build, might be a good idea.